### PR TITLE
Fix yunohost-config-dspam postrm

### DIFF
--- a/yunohost-config-dspam/debian/postrm
+++ b/yunohost-config-dspam/debian/postrm
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
brackets are not sh-compatible

admin@yunohost:~$ sh -c "ls /etc/dspam/{dspam.conf,default.prefs}"
ls: cannot access /etc/dspam/{dspam.conf,default.prefs}: No such file or directory

admin@yunohost:~$ bash -c "ls /etc/dspam/{dspam.conf,default.prefs}"
/etc/dspam/default.prefs  /etc/dspam/dspam.conf
