### PR TITLE
Fix bash if test to be safer

### DIFF
--- a/yunohost-config-tahoe/debian/postinst
+++ b/yunohost-config-tahoe/debian/postinst
@@ -8,7 +8,7 @@ if [ ! -d /home/yunohost.backup ]; then
 	mkdir /home/yunohost.backup
 fi
 
-if [ -d /home/yunohost.backup/tahoe ] && [ -f /etc/yunohost/yunohost.conf ] && [ $(grep backup /etc/yunohost/yunohost.conf | cut -d= -f2) = "no" ];
+if [[ -d /home/yunohost.backup/tahoe ]] && [[ -f /etc/yunohost/yunohost.conf ]] && [[ $(grep backup /etc/yunohost/yunohost.conf | cut -d= -f2) = "no" ]];
 then
         cp $TMP/backup/tahoe.cfg /home/yunohost.backup/tahoe/
 	#service tahoe-lafs restart


### PR DESCRIPTION
This will solve an issue like :" line 11: [: =: unary operator expected" in the case one of the operators are empty or missing.
