### PR TITLE
Pour que le menu soie supporté aussi dans owncloud

### DIFF
--- a/yunohost-config-nginx/config/yunohost_panel.conf.inc
+++ b/yunohost-config-nginx/config/yunohost_panel.conf.inc
@@ -1,2 +1,2 @@
-sub_filter <head> '<head><script type="text/javascript" src="/ynhpanel.js"></script>';
+sub_filter </head> '<script type="text/javascript" src="/ynhpanel.js"></script></head>';
 sub_filter_once on;


### PR DESCRIPTION
Owncloud as une entête <head> spécifique exemple : <head data-user="user" data-requesttoken="fdk12ek12ejl12ekj1le21213"> de ce fait il n'est pas pris en compte par nginx.
