### PR TITLE
Avoid spreading metronome logs at different places

### DIFF
--- a/metronome/config/metronome.cfg.lua
+++ b/metronome/config/metronome.cfg.lua
@@ -24,9 +24,9 @@
 pidfile = "/var/run/metronome/metronome.pid"
 
 log = {
-	info = "/var/log/metronome/metronome.log"; -- Change 'info' to 'debug' for verbose logging
+	debug = "/var/log/metronome/metronome.log"; -- Change 'debug' to 'info' for less verbose logging
 	error = "/var/log/metronome/metronome.err";
-	"*syslog";
+	-- "*syslog";
 }
 
 modules_enabled = {


### PR DESCRIPTION
Previously, we had : 
info logs going to /var/log/metronome/metronome.log
error logs going to /var/log/metronome/metronome.err
debug logs going to /var/log/syslog

Now, info+debug logs all go to /var/log/metronome/metronome.log, and we don't use syslog anymore.
