### PR TITLE
[enh] be less verbose in the postfix banner

### DIFF
--- a/yunohost-config-postfix/config/postfix/main.cf
+++ b/yunohost-config-postfix/config/postfix/main.cf
@@ -6,7 +6,7 @@
 # is /etc/mailname.
 #myorigin = /etc/mailname
 
-smtpd_banner = $myhostname ESMTP $mail_name (Debian/GNU)
+smtpd_banner = $myhostname Service ready
 biff = no
 
 # appending .domain is the MUA's job.

--- a/yunohost-config-postfix/config/postfix/main.cf-dspam
+++ b/yunohost-config-postfix/config/postfix/main.cf-dspam
@@ -6,7 +6,7 @@
 # is /etc/mailname.
 #myorigin = /etc/mailname
 
-smtpd_banner = $myhostname ESMTP $mail_name (Debian/GNU)
+smtpd_banner = $myhostname Service ready
 biff = no
 
 # appending .domain is the MUA's job.

--- a/yunohost-config-postfix/config/postfix/main.cf-dspam-ipv4
+++ b/yunohost-config-postfix/config/postfix/main.cf-dspam-ipv4
@@ -6,7 +6,7 @@
 # is /etc/mailname.
 #myorigin = /etc/mailname
 
-smtpd_banner = $myhostname ESMTP $mail_name (Debian/GNU)
+smtpd_banner = $myhostname Service ready
 biff = no
 
 # appending .domain is the MUA's job.

--- a/yunohost-config-postfix/config/postfix/main.cf-ipv4
+++ b/yunohost-config-postfix/config/postfix/main.cf-ipv4
@@ -6,7 +6,7 @@
 # is /etc/mailname.
 #myorigin = /etc/mailname
 
-smtpd_banner = $myhostname ESMTP $mail_name (Debian/GNU)
+smtpd_banner = $myhostname Service ready
 biff = no
 
 # appending .domain is the MUA's job.


### PR DESCRIPTION
We only need to comply with RFC 2821 :
http://tools.ietf.org/html/rfc2821

See paragraph : 4.3.1 Sequencing Overview
- don't say it's postfix
- don't say it's Debian
