### PR TITLE
[enh] Enable Postfix on submission port and update TLS related conf

### DIFF
--- a/yunohost-config-postfix/config/postfix/main.cf
+++ b/yunohost-config-postfix/config/postfix/main.cf
@@ -17,14 +17,20 @@ append_dot_mydomain = no
 
 readme_directory = no
 
-# TLS parameters
+# TLS for incoming connections
+smtpd_tls_security_level=may
+smtpd_tls_auth_only=yes
 smtpd_tls_cert_file=/etc/ssl/certs/yunohost_crt.pem
 smtpd_tls_key_file=/etc/ssl/private/yunohost_key.pem
 smtpd_tls_CAfile = /etc/ssl/certs/ca-yunohost_crt.pem
-smtpd_use_tls=yes
 smtpd_tls_exclude_ciphers = aNULL, MD5, DES, ADH
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
+smtpd_tls_loglevel=1
+
+# TLS for outgoing connections
+smtp_tls_security_level=may
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+smtp_tls_loglevel=1
 
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
 # information on enabling SSL in the smtp client.

--- a/yunohost-config-postfix/config/postfix/main.cf-ipv4
+++ b/yunohost-config-postfix/config/postfix/main.cf-ipv4
@@ -17,14 +17,20 @@ append_dot_mydomain = no
 
 readme_directory = no
 
-# TLS parameters
+# TLS for incoming connections
+smtpd_tls_security_level=may
+smtpd_tls_auth_only=yes
 smtpd_tls_cert_file=/etc/ssl/certs/yunohost_crt.pem
 smtpd_tls_key_file=/etc/ssl/private/yunohost_key.pem
 smtpd_tls_CAfile = /etc/ssl/certs/ca-yunohost_crt.pem
-smtpd_use_tls=yes
 smtpd_tls_exclude_ciphers = aNULL, MD5, DES, ADH
 smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
+smtpd_tls_loglevel=1
+
+# TLS for outgoing connections
+smtp_tls_security_level=may
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+smtp_tls_loglevel=1
 
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
 # information on enabling SSL in the smtp client.

--- a/yunohost-config-postfix/config/postfix/master.cf
+++ b/yunohost-config-postfix/config/postfix/master.cf
@@ -9,10 +9,10 @@
 #               (yes)   (yes)   (yes)   (never) (100)
 # ==========================================================================
 smtp      inet  n       -       -       -       -       smtpd
-#submission inet n       -       -       -       -       smtpd
-#  -o smtpd_tls_security_level=encrypt
-#  -o smtpd_sasl_auth_enable=yes
-#  -o smtpd_client_restrictions=permit_sasl_authenticated,reject
+submission inet n       -       -       -       -       smtpd
+  -o smtpd_tls_security_level=encrypt
+  -o smtpd_sasl_auth_enable=yes
+  -o smtpd_client_restrictions=permit_sasl_authenticated,reject
 #  -o milter_macro_daemon_name=ORIGINATING
 smtps     inet  n       -       -       -       -       smtpd
   -o smtpd_tls_wrappermode=yes


### PR DESCRIPTION
Update main configuration for TLS support and enable submission service (port 587) to allow only TLS connection on it - based on [this tutorial](http://docs.homelinux.org/postfix:configure_postfix_with_tls).

I'm not sure about the _smtpd_tls_auth_only_ since - as better explained [here](http://www.postfix.org/TLS_README.html#server_tls_auth) - it can be either a security risk or a non-compatibility issue with non-TLS clients... What's the most important? Since at the moment it's still possible to connect with SSL on the - yet depreciated - port 465.
