### PR TITLE
[fix] Add wheezy-backports repo to provide an up-to-date nginx version

### DIFF
--- a/yunohost-config-nginx/debian/control
+++ b/yunohost-config-nginx/debian/control
@@ -7,7 +7,8 @@ Standards-Version: 3.9.1
 
 Package: yunohost-config-nginx
 Architecture: all
-Depends: php5-fpm, php5-ldap, php5-mysql | php5-mysqlnd, php5-gd, php5-curl, php5-mcrypt, php5-intl, php-gettext, yunohost-config-others, openresty (>=1.4.1) | nginx-extras (>=1.4.1)
+Pre-Depends: yunohost-predepends (>=2.0-rc1~megusta2)
+Depends: php5-fpm, php5-ldap, php5-mysql | php5-mysqlnd, php5-gd, php5-curl, php5-mcrypt, php5-intl, php-gettext, yunohost-config-others, openresty (>=1.4.1) | nginx-extras (>=1.6.2)
 Replaces: apache2.2-common
 Conflicts: apache2.2-common
 Homepage: http://www.yunohost.org

--- a/yunohost-predepends/config/apt/00-nginx.pref
+++ b/yunohost-predepends/config/apt/00-nginx.pref
@@ -1,0 +1,3 @@
+Package: nginx-extras nginx-common libluajit-5.1-2 libluajit-5.1-common init-system-helpers
+Pin: release a=wheezy-backports
+Pin-Priority: 990

--- a/yunohost-predepends/debian/install
+++ b/yunohost-predepends/debian/install
@@ -1,1 +1,2 @@
+config/apt/*.pref /etc/apt/preferences.d/
 config/dovecot/* /etc/dovecot/

--- a/yunohost-predepends/debian/postinst
+++ b/yunohost-predepends/debian/postinst
@@ -1,0 +1,54 @@
+#!/bin/sh
+# postinst script for yunohost-predepends
+
+set -e
+
+# summary of how this script can be called:
+#        * <postinst> `configure' <most-recently-configured-version>
+#        * <old-postinst> `abort-upgrade' <new version>
+#        * <conflictor's-postinst> `abort-remove' `in-favour' <package>
+#          <new-version>
+#        * <deconfigured's-postinst> `abort-deconfigure' `in-favour'
+#          <failed-install-package> <version> `removing'
+#          <conflicting-package> <version>
+# for details, see http://www.debian.org/doc/debian-policy/ or
+# the debian-policy package
+
+case "$1" in
+  configure)
+    # Add wheezy-backports repository if needed
+    if [ -z "$(apt-cache policy |grep -e " wheezy-backports/main ")" ];
+    then
+        # Retrieve current mirror for wheezy
+        mirror=$(cat /etc/apt/sources.list |grep -m1 -e "^deb .* wheezy main"| awk '{ print $2 }')
+ 
+        # Check if wheezy-backports is not available
+        if wget -q0- "${mirror}/dists/wheezy-backports/Release" >/dev/null;
+        then
+            mirror="http://cdn.debian.net/debian"
+        fi
+
+        # Define the sources list's file
+        if [ ! -d "/etc/apt/sources.list.d" ];
+        then
+            sources=/etc/apt/sources.list
+        else
+            sources=/etc/apt/sources.list.d/wheezy-backports.list
+        fi
+
+        # Add the new entries
+        echo "deb ${mirror} wheezy-backports main" >> $sources
+        echo "deb-src ${mirror} wheezy-backports main" >> $sources
+
+        echo "You will have to resynchronize the package index files by running 'apt-get update'" >&2
+    fi
+  ;;
+  abort-upgrade|abort-remove|abort-deconfigure)
+  ;;
+  *)
+    echo "postinst called with unknown argument \`$1'" >&2
+    exit 1
+  ;;
+esac
+
+#DEBHELPER#


### PR DESCRIPTION
This add the wheezy-backports repo in order to provide an up-to-date version for nginx - since the current one is frozen in an unmaintained state.

The configuration files have changed and there is especially one big change, the `SCRIPT_FILENAME` is not defined anymore in `/etc/nginx/fastcgi_params`. That's why each app using at least *fastcgi* will have to be checked and updated, since overwriting parameters of this file is maybe not the best way to go. A diff of main changes can be found here: http://pad.thomaslebeau.fr/p/nginx.diff